### PR TITLE
Installer.run() semicolon bug

### DIFF
--- a/src/lib/install/DatabaseInstaller.class.php
+++ b/src/lib/install/DatabaseInstaller.class.php
@@ -89,7 +89,10 @@ abstract class DatabaseInstaller {
 
 		// Remove /* */ comments
 		$statements = preg_replace('#/\*.*\*/#', '', $statements);
-		$statements = explode(';', $statements);
+		// split on semicolons that are outside of single quotes
+		// http://stackoverflow.com/questions/21105360/regex-find-comma-not-inside-quotes
+		$statements = preg_split("/(?!\B'[^']*);(?![^']*'\B)/", $statements);
+
 		foreach ($statements as $sql) {
 			$sql = trim($sql);
 			if ($sql !== '') {


### PR DESCRIPTION
Fix bug semicolon bug where sql statements are prematurely split by DatabaseInstaller.bug()