### PR TITLE
Issue 34

### DIFF
--- a/src/lib/classes/GeoserveWebService.class.php
+++ b/src/lib/classes/GeoserveWebService.class.php
@@ -128,10 +128,10 @@ class GeoserveWebService {
         $query->latitude = $this->validateFloat($name, $value, -90, 90);
       } else if ($name === 'minlatitude') {
         $rectangleSearch = true;
-        $query->minlatitude = validateFloat($name, $value, -90, 90);
+        $query->minlatitude = $this->validateFloat($name, $value, -90, 90);
       } else if ($name === 'maxlatitude') {
         $rectangleSearch = true;
-        $query->maxlatitude = validateFloat($name, $value, -90, 90);
+        $query->maxlatitude = $this->validateFloat($name, $value, -90, 90);
       } else if ($name ==='longitude' || $name ==='lon') {
         $circleSearch = true;
         $query->longitude = $this->validateFloat($name, $value, -180, 180);

--- a/src/lib/classes/GeoserveWebService.class.php
+++ b/src/lib/classes/GeoserveWebService.class.php
@@ -167,7 +167,7 @@ class GeoserveWebService {
 
     if ($rectangleSearch &&
         ($query->minlatitude === null || $query->maxlatitude === null ||
-        $query->minlongitude === null || $query->maxlongitude === null ||)) {
+        $query->minlongitude === null || $query->maxlongitude === null)) {
       $this->error(self::BAD_REQUEST,
           'min/max latitude/longitude are required for rectangle searches');
     }

--- a/src/lib/classes/PlacesCallback.class.php
+++ b/src/lib/classes/PlacesCallback.class.php
@@ -30,10 +30,10 @@ class PlacesCallback extends GeoserveCallback {
           '"properties":{',
             '"admin1_code":"', $item['admin1_code'], '",',
             '"admin1_name":"', $item['admin1_name'], '",',
-            '"azimuth":', round($item['azimuth'], 1), ',',
+            '"azimuth":', $this->_round($item['azimuth'], 1), ',',
             '"country_code":"', $item['country_code'], '",',
             '"country_name":"', $item['country_name'], '",',
-            '"distance":', round($item['distance'], 3), ',',
+            '"distance":', $this->_round($item['distance'], 3), ',',
             '"feature_class":"', $item['feature_class'], '",',
             '"feature_code":"', $item['feature_code'], '",',
             '"name":"', $item['name'], '",',
@@ -51,4 +51,11 @@ class PlacesCallback extends GeoserveCallback {
     $this->count++;
   }
 
+  protected function _round ($number, $decimals) {
+    if ($number === null) {
+      return 'null';
+    }
+
+    return round($number, $decimals);
+  }
 }

--- a/src/lib/classes/PlacesFactory.class.php
+++ b/src/lib/classes/PlacesFactory.class.php
@@ -102,14 +102,4 @@ class PlacesFactory extends GeoserveFactory {
       }
     }
   }
-
-  /**
-   * @Deprecated
-   * @See PlacesFacgtory#get
-   *
-   */
-  public function getPlaces ($query, $callback = null) {
-    return $this->get($query, $callback);
-  }
-
 }

--- a/src/lib/classes/PlacesFactory.class.php
+++ b/src/lib/classes/PlacesFactory.class.php
@@ -22,21 +22,36 @@ class PlacesFactory extends GeoserveFactory {
    *         if at least one of $query->limit or $query->maxradiuskm
    *         is not specified.
    */
-  public function get($query, $callback=null) {
+  public function get ($query, $callback=null) {
+
+    if ($query->latitude !== null && $query->longitude !== null &&
+        $query->maxradiuskm !== null) {
+      return $this->getByCircle($query, $callback);
+    } else if ($query->minlatitude !== null && $query->maxlatitude !== null &&
+        $query->minlongitude !== null && $query->maxlongitude !== null) {
+      return $this->getByRectangle($query, $callback);
+    } else {
+      throw new Exception('Neither circle nor rectangle parameters provided.');
+    }
+  }
+
+  /**
+   * Get nearby places for circle searches.
+   *
+   */
+  public function getByCircle ($query, $callback = null) {
     if ($query->latitude === null || $query->longitude === null ||
         $query->maxradiuskm === null) {
       throw new Exception('"latitude", "longitude", and "maxradiuskm"' .
           ' are required');
     }
 
-    // connect to database
-    $db = $this->connect();
-
     // create sql
     $sql = 'WITH search AS (SELECT' .
         ' ST_SetSRID(ST_MakePoint(:longitude,:latitude),4326)::geography' .
         ' AS point' .
         ')';
+
     // bound parameters
     $params = array(
         ':latitude' => $query->latitude,
@@ -53,21 +68,23 @@ class PlacesFactory extends GeoserveFactory {
         ' JOIN admin1_codes_ascii ON (geoname.country_code || \'.\' ||' .
             ' geoname.admin1_code = admin1_codes_ascii.code)'.
         ' JOIN country_info ON (geoname.country_code = country_info.iso)';
+
     // build where clause
     $where = array();
     if ($query->maxradiuskm !== null) {
       $where[] = 'ST_DWithin(search.point, geoname.shape, :distance)';
       $params[':distance'] = $query->maxradiuskm * 1000;
     }
-    if ($query->minpopulation !== null) {
-      $where[] = 'geoname.population >= :minpopulation';
-      $params[':minpopulation'] = $query->minpopulation;
-    }
+
+    $this->_buildGenericWhere($query, $where, $params);
+
     if (count($where) > 0) {
       $sql .= ' WHERE ' . implode(' AND ', $where);
     }
+
     // sort closest places first
     $sql .= ' ORDER BY distance';
+
     // limit number of results
     if ($query->limit !== null) {
       $sql .= ' LIMIT :limit';
@@ -75,7 +92,100 @@ class PlacesFactory extends GeoserveFactory {
     }
 
     // execute query
+    return $this->_execute($sql, $params, $callback);
+  }
+
+  /**
+   * Get places for rectangle searches.
+   *
+   * Note :: Unlike with cicles, there is no azimuth or distance generated
+   * since there is no "center" of interest per-se.
+   *
+   */
+  public function getByRectangle ($query, $callback = null) {
+    if ($query->minlatitude === null || $query->maxlatitude === null ||
+        $query->minlongitude === null || $query->maxlongitude === null) {
+      throw new Exception('"minlatitude", "maxlatitude", "minlongitude", ',
+          '"maxlongitude" are required parameters');
+    }
+
+    $sql = '
+    SELECT
+      geoname.*,
+      admin1_codes_ascii.name AS admin1_name,
+      country_info.country AS country_name
+    FROM
+      geoname
+    JOIN
+      admin1_codes_ascii ON (geoname.country_code || \'.\' || ' .
+          'geoname.admin1_code = admin1_codes_ascii.code)
+    JOIN
+      country_info ON (geoname.country_code = country_info.iso)
+    WHERE
+    ';
+
+    $where = array();
+    $params = array(
+      'minlatitude' => $query->minlatitude,
+      'maxlatitude' => $query->maxlatitude,
+      'minlongitude' => $this->_normalizeLongitude($query->minlongitude),
+      'maxlongitude' => $this->_normalizeLongitude($query->maxlongitude)
+    );
+
+    if ($params['minlongitude'] > $params['maxlongitude']) {
+      // crosses dateline, make two boxes
+      $sql .= '((
+          geoname.shape &&
+          ST_MakeEnvelope(:minlongitude, :minlatitude, 180, :maxlatitude, 4326)
+        ) OR (
+          geoname.shape &&
+          ST_MakeEnvelope(-180, :minlatitude, :maxlongitude, :maxlatitude, 4326)
+      ))';
+    } else {
+      $sql .= '(geoname.shape && ST_MakeEnvelope(' .
+          ':minlongitude, :minlatitude, :maxlongitude, :maxlatitude, 4326))';
+    }
+
+    $this->_buildGenericWhere($query, $where, $params);
+
+    if (count($where) > 0) {
+      $sql .= ' AND ' . implode(' AND ', $where);
+    }
+
+    // sort populous places first
+    $sql .= ' ORDER BY geoname.population DESC';
+
+    // limit number of results
+    if ($query->limit !== null) {
+      $sql .= ' LIMIT :limit';
+      $params[':limit'] = $query->limit;
+    }
+
+    // execute query
+    return $this->_execute($sql, $params, $callback);
+  }
+
+  /**
+   * Generic method for parsing "WHERE" parameters that are common to both
+   * circle and rectangle searches.
+   *
+   */
+  private function _buildGenericWhere ($query, &$where, &$params) {
+    if ($query->minpopulation !== null) {
+      $where[] = 'geoname.population >= :minpopulation';
+      $params[':minpopulation'] = $query->minpopulation;
+    }
+  }
+
+  /**
+   * Excutes the query either invoking the callback if provided or returning
+   * the result set otherwise.
+   *
+   */
+  private function _execute ($sql, $params, $callback = null) {
+    $db = $this->connect();
     $query = $db->prepare($sql);
+
     if (!$query->execute($params)) {
       // handle error
       $errorInfo = $db->errorInfo();
@@ -87,19 +197,39 @@ class PlacesFactory extends GeoserveFactory {
     } else {
       try {
         if ($callback !== null) {
-          // use callback
           $callback->onStart($query);
+
           while ($row = $query->fetch(PDO::FETCH_ASSOC)) {
             $callback->onPlace($row, $this);
           }
+
           $callback->onEnd();
         } else {
-          // return all places
           return $query->fetchAll(PDO::FETCH_ASSOC);
         }
       } finally {
         $query->closeCursor();
       }
     }
+  }
+
+  /**
+   * Maps the input longitude into a [-180,.0 +180.0] range.
+   *
+   */
+  private function _normalizeLongitude ($longitude) {
+    if ($longitude === null) {
+      return null;
+    }
+
+    while ($longitude < -180.0) {
+      $longitude += 360.0;
+    }
+
+    while ($longitude > 180.0) {
+      $longitude -= 360.0;
+    }
+
+    return $longitude;
   }
 }

--- a/src/lib/classes/PlacesFactory.class.php
+++ b/src/lib/classes/PlacesFactory.class.php
@@ -113,7 +113,9 @@ class PlacesFactory extends GeoserveFactory {
     SELECT
       geoname.*,
       admin1_codes_ascii.name AS admin1_name,
-      country_info.country AS country_name
+      country_info.country AS country_name,
+      NULL::DECIMAL AS azimuth,
+      NULL::DECIMAL AS distance
     FROM
       geoname
     JOIN

--- a/src/lib/classes/PlacesQuery.class.php
+++ b/src/lib/classes/PlacesQuery.class.php
@@ -5,6 +5,12 @@ class PlacesQuery {
   public $latitude = null;
   public $longitude = null;
 
+  public $minlatitude = null;
+  public $maxlatitude = null;
+
+  public $minlongitude = null;
+  public $maxlongitude = null;
+
   // places
   public $maxradiuskm = null;
   public $minpopulation = null;


### PR DESCRIPTION
Fixes usgs/hazdev-geoserve-ws#34

Lacking a point-of-interest, the following caveats apply:
- Distance is not computed
- Azimuth is not computed
- Order is based on population size

We could try to imply a point-of-interest by computing the center of the rectangle, but that might not be appropriate or accurate.