### PR TITLE
fixed proxy version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gateway": "^1.0.0",
     "grunt": "^0.4.5",
     "grunt-concurrent": "^1.0.0",
-    "grunt-connect-proxy": "^0.1.11",
+    "grunt-connect-proxy": "0.1.10",
     "grunt-connect-rewrite": "^0.2.1",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-compass": "^1.0.1",


### PR DESCRIPTION
the current version of grunt-connect-proxy 0.1.11 does not work. Changed the version to 0.1.10 this allows grunt to work correctly.