### PR TITLE
validation fix

### DIFF
--- a/src/lib/classes/GeoserveWebService.class.php
+++ b/src/lib/classes/GeoserveWebService.class.php
@@ -214,7 +214,7 @@ class GeoserveWebService {
         // not event type search
         if ($query->limit === null && $query->maxradiuskm === null) {
           $this->error(self::BAD_REQUEST,
-            'circle search requires "limit" or "maxradiuskm"');
+            'circle search requires "limit" and/or "maxradiuskm"');
         }
       }
 

--- a/src/lib/classes/GeoserveWebService.class.php
+++ b/src/lib/classes/GeoserveWebService.class.php
@@ -210,10 +210,11 @@ class GeoserveWebService {
         $this->error(self::BAD_REQUEST,
             'latitude and longitude are required for circle searches');
       }
-      if (!in_array('event', $query->type)) {
+      if (in_array('geonames', $query->type)) {
         // not event type search
         if ($query->limit === null && $query->maxradiuskm === null) {
-          $this->error('circle search requires "limit" and/or "maxradiuskm"');
+          $this->error(self::BAD_REQUEST,
+            'circle search requires "limit" or "maxradiuskm"');
         }
       }
 

--- a/src/lib/classes/PlacesFactory.class.php
+++ b/src/lib/classes/PlacesFactory.class.php
@@ -35,7 +35,7 @@ class PlacesFactory extends GeoserveFactory {
     if ($query->latitude === null || $query->longitude === null) {
       throw new Exception('"latitude" and "longitude" are required');
     } else if ($query->maxradiuskm === null && $query->limit === null) {
-      throw new Exception('"limit" and/or "maxradiuskm" are required');
+      throw new Exception('"limit" or "maxradiuskm" are required');
     }
 
     if ($query->maxradiuskm === null) {

--- a/src/lib/classes/PlacesFactory.class.php
+++ b/src/lib/classes/PlacesFactory.class.php
@@ -35,7 +35,7 @@ class PlacesFactory extends GeoserveFactory {
     if ($query->latitude === null || $query->longitude === null) {
       throw new Exception('"latitude" and "longitude" are required');
     } else if ($query->maxradiuskm === null && $query->limit === null) {
-      throw new Exception('"limit" or "maxradiuskm" are required');
+      throw new Exception('"limit" and/or "maxradiuskm" are required');
     }
 
     if ($query->maxradiuskm === null) {


### PR DESCRIPTION
Ensure validation fails when a geonames type query is attempted without a limit or maxradiuskm

Test using:
http://localhost:8100/ws/geoserve/places?latitude=39.75&longitude=-105.2