### PR TITLE
Update _round() to return null instead of "null" when value is null

### DIFF
--- a/src/lib/classes/PlacesFormatter.class.php
+++ b/src/lib/classes/PlacesFormatter.class.php
@@ -46,7 +46,7 @@ class PlacesFormatter extends GeoserveFormatter {
 
   protected function _round ($number, $decimals) {
     if ($number === null) {
-      return 'null';
+      return null;
     }
 
     return round($number, $decimals);


### PR DESCRIPTION
This can be closed if there is some reason that we prefer "null" over null for properties in the GeoJSON feed.