### PR TITLE
changed url to new geonames data location

### DIFF
--- a/src/lib/load_geonames.php
+++ b/src/lib/load_geonames.php
@@ -23,7 +23,7 @@ echo "Success!!\n";
 
 // download geoname data
 echo "\nDownloading and loading geonames data:\n";
-$url = configure('GEONAMES_URL', 'http://download.geonames.org/export/dump/',
+$url = configure('GEONAMES_URL', 'ftp://hazards.cr.usgs.gov/web/hazdev-geoserve-ws/geonames/',
     "Geonames download url");
 $filenames = array('cities1000.zip', 'US.zip', 'admin1CodesASCII.txt',
     'countryInfo.txt');


### PR DESCRIPTION
Fixes usgs/hazdev-geoserve-ws#74

- Created geonames dir on hazdev ftp and added 4 files to it. Located here. ftp://hazards.cr.usgs.gov/web/hazdev-geoserve-ws/geonames/
- Changed url to new location
