### PR TITLE
Add 'Type' to authoritative regions test.

### DIFF
--- a/test/spec/geoserve/AuthoritativeRegionViewTest.js
+++ b/test/spec/geoserve/AuthoritativeRegionViewTest.js
@@ -42,10 +42,16 @@ describe('AuthoritativeRegionView test suite.', function () {
         model: Model({regions: region})
       });
 
-      expect(div.innerHTML).to.be.equal('<dl class="horizontal">' +
-          '<dt>Name</dt><dd>PAS</dd>' +
-          '<dt>Network</dt><dd>CI</dd>' +
-        '</dl>');
+      expect(div.innerHTML).to.be.equal(
+        '<dl class="horizontal">' +
+          '<dt>Name</dt>' +
+            '<dd>PAS</dd>' +
+          '<dt>Network</dt>' +
+            '<dd>CI</dd>' +
+          '<dt>Type</dt>' +
+            '<dd>ANSS</dd>' +
+        '</dl>'
+      );
     });
 
     it('shows custom message when no data is available', function () {


### PR DESCRIPTION
All tests now pass.

Fixes usgs/hazdev-geoserve-ws#139