### PR TITLE
Change polygon columns to Geometry instead of Geography

### DIFF
--- a/src/lib/classes/RegionsFactory.class.php
+++ b/src/lib/classes/RegionsFactory.class.php
@@ -70,7 +70,7 @@ class RegionsFactory extends GeoserveFactory {
 
     // create sql
     $sql = 'WITH search AS (SELECT' .
-        ' ST_SetSRID(ST_MakePoint(:longitude,:latitude),4326)::geography' .
+        ' ST_SetSRID(ST_MakePoint(:longitude,:latitude),4326)::geometry' .
         ' AS point' .
         ')';
     // bound parameters
@@ -111,7 +111,7 @@ class RegionsFactory extends GeoserveFactory {
 
     // create sql
     $sql = 'WITH search AS (SELECT' .
-      ' ST_SetSRID(ST_MakePoint(:longitude,:latitude),4326)::geography' .
+      ' ST_SetSRID(ST_MakePoint(:longitude,:latitude),4326)::geometry' .
       ' AS point' .
       ')';
     //bound parameters
@@ -152,7 +152,7 @@ class RegionsFactory extends GeoserveFactory {
 
     // create sql
     $sql = 'WITH search AS (SELECT' .
-        ' ST_SetSRID(ST_MakePoint(:longitude,:latitude),4326)::geography' .
+        ' ST_SetSRID(ST_MakePoint(:longitude,:latitude),4326)::geometry' .
         ' AS point' .
         ')';
     // bound parameters
@@ -197,7 +197,7 @@ class RegionsFactory extends GeoserveFactory {
 
     // create sql
     $sql = 'WITH search AS (SELECT' .
-        ' ST_SetSRID(ST_MakePoint(:longitude,:latitude),4326)::geography' .
+        ' ST_SetSRID(ST_MakePoint(:longitude,:latitude),4326)::geometry' .
         ' AS point' .
         ')';
     // bound parameters
@@ -260,7 +260,7 @@ class RegionsFactory extends GeoserveFactory {
 
     // create sql
     $sql = 'WITH search AS (SELECT' .
-        ' ST_SetSRID(ST_MakePoint(:longitude,:latitude),4326)::geography' .
+        ' ST_SetSRID(ST_MakePoint(:longitude,:latitude),4326)::geometry' .
         ' AS point' .
         ')';
     // bound parameters
@@ -300,7 +300,7 @@ class RegionsFactory extends GeoserveFactory {
 
     // create sql
     $sql = 'WITH search AS (SELECT' .
-        ' ST_SetSRID(ST_MakePoint(:longitude,:latitude),4326)::geography' .
+        ' ST_SetSRID(ST_MakePoint(:longitude,:latitude),4326)::geometry' .
         ' AS point' .
         ')';
     // bound parameters

--- a/src/lib/sql/pgsql/admin.sql
+++ b/src/lib/sql/pgsql/admin.sql
@@ -19,7 +19,7 @@ CREATE TABLE admin (
   iso      CHAR(3),
   country  VARCHAR(100),
   region   VARCHAR(100),
-  shape    GEOGRAPHY(GEOMETRY, 4326)
+  shape    GEOMETRY(GEOMETRY, 4326)
 );
 
 /* Indexes */

--- a/src/lib/sql/pgsql/authoritative.sql
+++ b/src/lib/sql/pgsql/authoritative.sql
@@ -20,7 +20,7 @@ CREATE TABLE authoritative (
   type      VARCHAR(50),
   priority  INTEGER,
   network   VARCHAR(10),
-  shape     GEOGRAPHY(GEOMETRY, 4326)
+  shape     GEOMETRY(GEOMETRY, 4326)
 );
 
 /* Indexes */

--- a/src/lib/sql/pgsql/fe.sql
+++ b/src/lib/sql/pgsql/fe.sql
@@ -23,13 +23,13 @@ CREATE TABLE fe (
   id     INTEGER PRIMARY KEY,
   num    INTEGER,
   place  VARCHAR(100),
-  shape  GEOGRAPHY(GEOMETRY, 4326)
+  shape  GEOMETRY(GEOMETRY, 4326)
 );
 
 CREATE TABLE fe_rename (
   id     INTEGER PRIMARY KEY,
   place  VARCHAR(100),
-  shape  GEOGRAPHY(GEOMETRY, 4326)
+  shape  GEOMETRY(GEOMETRY, 4326)
 );
 
 /* Indexes */

--- a/src/lib/sql/pgsql/neic.sql
+++ b/src/lib/sql/pgsql/neic.sql
@@ -21,7 +21,7 @@ CREATE TABLE neic_catalog (
   name VARCHAR(50),
   magnitude DECIMAL(2, 1),
   type VARCHAR(50),
-  shape GEOGRAPHY(GEOMETRY, 4326)
+  shape GEOMETRY(GEOMETRY, 4326)
 );
 
 CREATE TABLE neic_response (
@@ -29,7 +29,7 @@ CREATE TABLE neic_response (
   name VARCHAR(50),
   magnitude DECIMAL(2, 1),
   type VARCHAR(50),
-  shape GEOGRAPHY(GEOMETRY, 4326)
+  shape GEOMETRY(GEOMETRY, 4326)
 );
 
 /* Indexes */

--- a/src/lib/sql/pgsql/tectonicsummary.sql
+++ b/src/lib/sql/pgsql/tectonicsummary.sql
@@ -19,7 +19,7 @@ CREATE TABLE tectonic_summary (
   name     VARCHAR(255),
   summary  text,
   type     VARCHAR(255),
-  shape    GEOGRAPHY(GEOMETRY, 4326)
+  shape    GEOMETRY(GEOMETRY, 4326)
 
 );
 

--- a/src/lib/sql/pgsql/timezone.sql
+++ b/src/lib/sql/pgsql/timezone.sql
@@ -21,7 +21,7 @@ CREATE TABLE timezone (
   dstend         VARCHAR(20),
   standardoffset int,
   dstoffset      int,
-  shape          GEOGRAPHY(GEOMETRY, 4326)
+  shape          GEOMETRY(GEOMETRY, 4326)
 );
 
 /* Indexes */


### PR DESCRIPTION
This, combined with data updates already uploaded to hazards, addresses issues with world default polygons.  Updated data and this branch are currently running on staging systems.


# updated data sets
- admin
- auth
- FE
- neic
- tectonic
- timezones

## explicit srid
Within each dataset i used the EWKT format to specify an SRID explicitly:
```
"POLYGON(...)"
"MULTIPOLYGON(...)"
```
Is now:
```
"SRID=4326;POLYGON(...)"
"SRID=4326;MULTIPOLYGON(...)"
```

## new world polygon
Additionally the default world polygons only included the southern hemisphere:
Old:
```
MULTIPOLYGON(
  ((-180 0,-90 0,-90 -90,-180 -90,-180 0)),
  ((-90 0,0 0,0 -90,-90 -90,-90 0)),
  ((0 0,90 0,90 -90,0 -90,0 0)),
  ((90 0,180 0,180 -90,90 -90,90 0)),
  ((-180 0,-90 0,-90 -90,-180 -90,-180 0)),
  ((-90 0,0 0,0 -90,-90 -90,-90 0)),
  ((0 0,90 0,90 -90,0 -90,0 0)),
  ((90 0,180 0,180 -90,90 -90,90 0))
)
```
New, note the last four polygons are now in the northern hemisphere:
```
SRID=4326;MULTIPOLYGON(
  ((-180 0,-90 0,-90 -90,-180 -90,-180 0)),
  ((-90 0,0 0,0 -90,-90 -90,-90 0)),
  ((0 0,90 0,90 -90,0 -90,0 0)),
  ((90 0,180 0,180 -90,90 -90,90 0)),
  ((-180 90,-90 90,-90 0,-180 0,-180 90)),
  ((-90 90,0 90,0 0,-90 0,-90 90)),
  ((0 90,90 90,90 0,0 0,0 90)),
  ((90 90,180 90,180 0,90 0,90 90))
)
```