### PR TITLE
Update azimuth to be calculated _from_ feature _to_ center point

### DIFF
--- a/src/lib/classes/PlacesFactory.class.php
+++ b/src/lib/classes/PlacesFactory.class.php
@@ -73,7 +73,7 @@ class PlacesFactory extends GeoserveFactory {
       geoname.*,
       admin1_codes_ascii.name as admin1_name,
       country_info.country as country_name,
-      degrees(ST_Azimuth(search.point, geoname.shape)) AS azimuth,
+      degrees(ST_Azimuth(geoname.shape, search.point)) AS azimuth,
       ST_Distance(search.point, geoname.shape) / 1000 AS distance
     FROM search, geoname
     JOIN admin1_codes_ascii ON (admin1_codes_ascii.code =


### PR DESCRIPTION
https://earthquake.usgs.gov/ws/geoserve/places.php reports `azimuth` to be:
> azimuth = Direction (in decimal degrees [0, 360]) from the Feature to the center point (latitude, longitude).

Below are attached example queries before this change.  These can be pasted into https://geojson.io , the red point is the search point and others are results.  Note the azimuth currently is reported _from_ the center point _to_ the feature point; so it is off by 180 degrees.

[utah_geoserve.txt](https://github.com/usgs/hazdev-geoserve-ws/files/2539783/utah_geoserve.txt)
[ca_geoserve.txt](https://github.com/usgs/hazdev-geoserve-ws/files/2539784/ca_geoserve.txt)


The ST_Azimuth is less than clear, but the images provide an explanation
https://postgis.net/docs/ST_Azimuth.html